### PR TITLE
Update et_xmlfile to version 1.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   description: |
     et_xmlfile is a low memory library for creating large XML files.
   doc_url: https://et-xmlfile.readthedocs.io
-  dev_url: https://bitbucket.org/openpyxl/et_xmlfile
+  dev_url: https://foss.heptapod.net/openpyxl/et_xmlfile
   doc_source_url: https://bitbucket.org/openpyxl/et_xmlfile/src/default/doc/index.rst
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,10 @@ requirements:
 test:
   imports:
     - et_xmlfile
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://bitbucket.org/openpyxl/et_xmlfile

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "et_xmlfile" %}
-{% set version = "1.0.1" %}
-{% set sha256 = "614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
1. check the upstream
there seems to be an issue with the upstream url
after checking in pypi.org 
https://pypi.org/project/et-xmlfile/
the following url was found and used for the review
https://foss.heptapod.net/openpyxl/et_xmlfile

2. check the pinnings
https://foss.heptapod.net/openpyxl/et_xmlfile/-/blob/branch/default/tox.ini
https://foss.heptapod.net/openpyxl/et_xmlfile/-/blob/branch/default/setup.py
https://foss.heptapod.net/openpyxl/et_xmlfile/-/blob/branch/default/pytest.ini
3. check changelogs
 a change log document was not available in the upstream. 
 To verify the changes we had to look at the list of issues and commits in the repository
https://foss.heptapod.net/openpyxl/et_xmlfile/activity

after reading through the activity log, the only changes seem to be bug fixes 

Closed
issue
#1
"build failed on python embed"
5 months 
Commented on
issue
#1
"build failed on python embed"
Fixed by r26

5 months 
Closed
issue
#2
"Update how compatible Python is specified in setup.py"
5 months 
Commented on
issue
#2
"Update how compatible Python is specified in setup.py"
Resolved in -r26

4. additional research
there were no significant open issues mentioned in conda-forge
https://github.com/conda-forge/et_xmlfile-feedstock/issues

5. verify dev_url
There are issues with the existing url
https://bitbucket.org/openpyxl/et_xmlfile
This is a suggested url
https://foss.heptapod.net/openpyxl/et_xmlfile

6. verify doc_url
https://bitbucket.org/openpyxl/et_xmlfile/src/default/doc/index.rst

7. added pip to the test section
8. verify the test section
9. additional tests

    In order to test the `et_xmlfile` packages the following command was used:
    `conda build et_xmlfile-feedstock --test`
    The final result was as follows:
    `All tests passed`

    To make sure the `et_xmlfile` package could be imported from other packages the following test was conducted.
    The `openpyxl` package was modified by changing the pinnings for the  `et_xmlfile` package to require version 1.1.0
    
    In order to conduct the test the following command was used:
    `conda build openpyxl-feedstock --test`
    the results were the following:
    `All tests passed`

based on the research conducted, and on the test results we can conclude that it is safe to update `et_xmlfile` to version 1.1.0
